### PR TITLE
Fix on firmware 01.07.01.00 and improve wifi connection setup

### DIFF
--- a/src/mqttmanager.h
+++ b/src/mqttmanager.h
@@ -141,11 +141,13 @@ void ParseCallback(JsonDocument &messageobject){
 
 void mqttCallback(char *topic, byte *payload, unsigned int length){
     DynamicJsonDocument messageobject(mqttdocument);
-    auto deserializeError = deserializeJson(messageobject, payload, length);
+
+    // Create filter to only grab "print" part from MQTT payload
+    StaticJsonDocument<64> filter;
+    filter["print"] = true;
+    
+    auto deserializeError = deserializeJson(messageobject, payload, length, DeserializationOption::Filter(filter));
     if (!deserializeError){
-        if (!messageobject.containsKey("print")) {
-            return;
-        }
         ParseCallback(messageobject);
     }else{
         Serial.println(F("Deserialize error while parsing mqtt"));

--- a/src/wifi-manager.h
+++ b/src/wifi-manager.h
@@ -39,21 +39,25 @@ bool setupWifi(){
     }
 
     while (connectionAttempts < maxConnectionAttempts) {
+        if (WiFi.status() == WL_CONNECTED)
+            break;
+        
         //WiFi.mode(WIFI_STA);
         WiFi.begin(globalVariables.SSID, globalVariables.APPW);
         delay(1000);
-        if (WiFi.status() != WL_CONNECTED){
-            Serial.print(F("Connecting to WIFI.. "));
-            Serial.println(globalVariables.SSID);
-            Serial.println(globalVariables.APPW);
-            delay(8000);
-        };
+        
+        Serial.print(F("Connecting to WIFI.. "));
+        Serial.println(globalVariables.SSID);
+        Serial.println(globalVariables.APPW);
+        delay(8000); // can probably be lower?
         connectionAttempts++;
     }
+    
     if (WiFi.status() != WL_CONNECTED){
         Serial.println(F("Failed to connect to wifi."));
         return false;
     }
+    
     int signalStrength = WiFi.RSSI();
     Serial.println(F("Connected To Wifi:"));
     Serial.println(signalStrength);


### PR DESCRIPTION
- Added a filter on Mqtt JSON data parsing so it only parses the "print" part of the payload. For more info on filters: https://arduinojson.org/v6/how-to/deserialize-a-very-large-document/
- During debugging from VSCode I noticed initial network setup took quite long. Turns out the while loop never exits, regardless of whether wifi connection succeeded or not. So I adjusted the while loop slightly to fix this issue. My ESP32 now always connects after first try. the 8 second delay can probably be reduced as well, although I did not test that as it wasn't within the scope of what I wanted to solve.

Tested on ESP32-WROVER. I expect this will work fine on ESP32-WROOM as well, although I have no idea about ESP8266.

I also had to disable merge_firmware.py on my local version as it would not build/deploy with that script. I don't know if this has any side-effects as I have no experience with this.


You can (and probably should) improve the filter further by really only filtering on the specific keys that are required for BLLed to function. Specifically the keys that are checked on in ``ParseCallback``. If the current fix proves insufficient for ESP8266, improving the filter might fix it for that one