### PR TITLE
Improve MQTT json filter

### DIFF
--- a/src/mqttmanager.h
+++ b/src/mqttmanager.h
@@ -141,17 +141,24 @@ void ParseCallback(JsonDocument &messageobject){
 
 void mqttCallback(char *topic, byte *payload, unsigned int length){
     DynamicJsonDocument messageobject(mqttdocument);
-
-    // Create filter to only grab "print" part from MQTT payload
-    StaticJsonDocument<64> filter;
-    filter["print"] = true;
     
-    auto deserializeError = deserializeJson(messageobject, payload, length, DeserializationOption::Filter(filter));
+    auto deserializeError = deserializeJson(messageobject, payload, length, DeserializationOption::Filter(getMqttPayloadFilter()));
     if (!deserializeError){
         ParseCallback(messageobject);
     }else{
         Serial.println(F("Deserialize error while parsing mqtt"));
     }
+}
+
+StaticJsonDocument<64> getMqttPayloadFilter()
+{
+    StaticJsonDocument<64> filter;
+    filter["print"]["stg_cur"] = true;
+    filter["print"]["gcode_state"] = true;
+    filter["print"]["lights_report"] = true;
+    filter["print"]["hms"] = true;
+    // Make sure to add more here when needed
+    return filter;
 }
 
 void setupMqtt(){


### PR DESCRIPTION
- Improved filter to really only grab the necessary info for BLLed.

I used an MQTT sniffer to check what data the bambu printer sends and was astounded by the large payload. I also noticed almost everything is located in "print" part, so to be quite honest I'm not 100% sure how the previous filter solved things.

Either way, this improved filter should really filter out a lot of data (eg "ams" object is quite large depending on amount of AMSes, this is now filtered out and thus in the future it should no longer matter how many AMSes someone has attached to their printer as they're completely ignored).