### PR TITLE
Update leds.h

### DIFF
--- a/src/leds.h
+++ b/src/leds.h
@@ -216,7 +216,7 @@ void updateleds(){
 
     //GREEN
 
-    if ((millis() - printerVariables.finishstartms) <= 300000 && printerVariables.gcodeState == "FINISH"){
+    if ((millis() - printerVariables.finishstartms) <= 300000 && printerVariables.gcodeState == "FINISH" && printerConfig.finishindication == true){
         tweenToColor(0,255,0,0,0,500); //ON
         if (printerConfig.debuging){
             Serial.println(F("Finished print, Turning Leds green"));


### PR DESCRIPTION
Updated to add a check to the control for Green LEDs, if Finish Indication feature is turned off now Green LEDs will be ignored after print finishes and White LEDs will remain on.