### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ extra_scripts =
 	pre:pre_build.py
 	merge_firmware.py
 lib_deps = 
-	https://github.com/bblanchon/ArduinoJson.git @ 7.0.4
+    https://github.com/bblanchon/ArduinoJson.git#36e1eec ;v7.0.4
 	https://github.com/knolleary/pubsubclient.git
 	luc-github/ESP32SSDP@^1.2.1
 


### PR DESCRIPTION
Update platformio.ini
Latest PlatformIO on Windows doesn't support `@` type of versioning, it requires commit hash instead. It produces error during build:
```
PackageException: Package version 7.2.1+sha.7946ebe doesn't satisfy requirements 7.0.4 based on PackageMetadata <type=library name=ArduinoJson version=7.2.1+sha.7946ebe spec={'owner': None, 'id': None, 'name': 'ArduinoJson', 'requirements': '7.0.4', 'uri': 'git+https://github.com/bblanchon/ArduinoJson.git'}
```